### PR TITLE
WP-18217 err handling for ten_secondly_rolling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-hubspot"
-version = "2.9.14"
+version = "2.9.15"
 description = "Singer.io tap for extracting data from the HubSpot API"
 authors = ["Stitch"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -245,6 +245,9 @@ def acquire_access_token_from_refresh_token():
             pass
 
         if message is not None:
+            if 'You have reached your ten_secondly_rolling limit' in message:
+                raise SymonException(f'You have reached the ten_secondly_rolling limit from Hubspot. Try importing fewer tables in a single batch.', 'hubspot.HubspotApiError')
+            
             raise SymonException(f'Import failed with the following Hubspot error: {message}', 'hubspot.HubspotApiError')
         raise
 
@@ -332,6 +335,9 @@ def request(url, params=None):
                 pass
 
             if message is not None:
+                if 'You have reached your ten_secondly_rolling limit' in message:
+                    raise SymonException(f'You have reached the ten_secondly_rolling limit from Hubspot. Try importing fewer tables in a single batch.', 'hubspot.HubspotApiError')
+                
                 raise SymonException(f'Import failed with the following Hubspot error: {message}', 'hubspot.HubspotApiError')
             raise
 
@@ -387,6 +393,9 @@ def post_search_endpoint(url, data, params=None):
                 pass
 
             if message is not None:
+                if 'You have reached your ten_secondly_rolling limit' in message:
+                    raise SymonException(f'You have reached the ten_secondly_rolling limit from Hubspot. Try importing fewer tables in a single batch.', 'hubspot.HubspotApiError')
+            
                 raise SymonException(f'Import failed with the following Hubspot error: {message}', 'hubspot.HubspotApiError')
             raise
 


### PR DESCRIPTION
JIRA: https://varicent.atlassian.net/browse/WP-18217

Better error handling for Hubspot ten_secondly_rolling limit.
This is a hard-coded throttle from Hubspot when too many requests are sent in the 10 second interval.