### PR TITLE
Add JIRA_API_TOKEN for Veracode cursor agent

### DIFF
--- a/.github/workflows/veracode-cursor-agent-fix.yml
+++ b/.github/workflows/veracode-cursor-agent-fix.yml
@@ -45,5 +45,6 @@ jobs:
           VERACODE_API_ID: ${{ secrets.VERACODE_API_KEY_ID }}
           VERACODE_API_KEY: ${{ secrets.VERACODE_API_KEY_SECRET }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }}
         run: |
           python tap-target-utils/cursor_agent.py


### PR DESCRIPTION
Adds `JIRA_API_TOKEN` secret to the Veracode cursor agent workflow so Jira ticket links appear in Slack notifications.